### PR TITLE
AHTI-416 | Add error toast to apollo network errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "react-router-dom": "^5.1.2",
     "react-slick": "^0.25.2",
     "react-swipeable-views": "^0.13.9",
+    "react-toastify": "^6.0.4",
     "resolve": "1.12.2",
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.0",

--- a/src/common/translation/i18n/translations/en.json
+++ b/src/common/translation/i18n/translations/en.json
@@ -2,7 +2,8 @@
   "common": {
     "back": "Back",
     "terms_of_service": "Terms of Service",
-    "all_rights_reserved": "All rights reserved"
+    "all_rights_reserved": "All rights reserved",
+    "network_error": "Your network has disconnected"
   },
   "index": {
     "main_header": "Discover the beautiful archipelago of Helsinki!",

--- a/src/common/translation/i18n/translations/fi.json
+++ b/src/common/translation/i18n/translations/fi.json
@@ -2,7 +2,8 @@
   "common": {
     "back": "Takaisin",
     "terms_of_service": "Käyttöehdot",
-    "all_rights_reserved": "Kaikki oikeudet pidätetään"
+    "all_rights_reserved": "Kaikki oikeudet pidätetään",
+    "network_error": "Verkkoyhteys on katkennut"
   },
   "index": {
     "main_header": "Löydä upea merellinen Helsinki!",

--- a/src/domain/Ahti/Ahti.tsx
+++ b/src/domain/Ahti/Ahti.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 import Footer from '../Footer/Footer';
 import ContentPage from '../ContentPage/ContentPage';
@@ -29,6 +31,7 @@ const Ahti: React.FC = () => {
           <Footer />
         </Route>
       </Switch>
+      <ToastContainer />
     </div>
   );
 };

--- a/src/domain/api/index.ts
+++ b/src/domain/api/index.ts
@@ -1,4 +1,5 @@
 import ApolloClient, { InMemoryCache } from 'apollo-boost';
+import { toast } from 'react-toastify';
 
 import i18n from '../../common/translation/i18n/i18n';
 import typeDefs from './client/typeDefs';
@@ -14,6 +15,19 @@ export default new ApolloClient({
           i18n.language || window.localStorage.i18nextLng || 'fi',
       },
     });
+  },
+  onError: ({ networkError }) => {
+    if (networkError) {
+      toast.error(i18n.t('common.network_error'), {
+        position: 'top-center',
+        autoClose: false,
+        hideProgressBar: true,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: false,
+        progress: undefined,
+      });
+    }
   },
   typeDefs,
   resolvers,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,6 +1515,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.7":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
+  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.4.0", "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -6536,6 +6543,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
+csstype@^2.6.7:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -6901,6 +6913,14 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
+  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^2.6.7"
 
 dom-serializer@0:
   version "0.2.2"
@@ -14587,6 +14607,25 @@ react-textarea-autosize@^7.1.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
+
+react-toastify@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-6.0.4.tgz#5a06f9ef29b9f257813fd0ab7c5b1f2aa9e33551"
+  integrity sha512-ieNHqMZim/8h0NfSigWsmqly9dG4JwtTnBCq3y5UVua73Os8VyvsZkdu5CHORqXXgIe9CGIIPz4AbIiFXWkLHg==
+  dependencies:
+    classnames "^2.2.6"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.1"
+
+react-transition-group@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Manual testing:
- Open contents page
- Disconnect network
- Try to open any item
- Instead of the site crashing, should display an error toast
- Once connectivity is re-established the app should continue to work normally